### PR TITLE
Don't build WavpackOpenFileInput for the ps2 and psp platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,9 @@ target_link_libraries(wavpack
         $<$<BOOL:${HAVE_LIBM}>:m>
 )
 add_library(WavPack::WavPack ALIAS wavpack)
+if(PSP OR PS2)
+    target_compile_definitions(wavpack PRIVATE DISABLE_WavpackOpenFileInput)
+endif()
 
 target_compile_definitions(wavpack
     PRIVATE
@@ -331,7 +334,7 @@ if(BUILD_SHARED_LIBS)
     endforeach()
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libwavpack.sym ${FILE_CONTENTS})
     if(CMAKE_VERSION VERSION_LESS 3.13)
-        set_target_properties(wavpack PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list,'${CMAKE_CURRENT_BINARY_DIR}/libwavpack.sym'") 
+        set_target_properties(wavpack PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list,'${CMAKE_CURRENT_BINARY_DIR}/libwavpack.sym'")
     else()
         target_link_directories(wavpack PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_BINARY_DIR}/libwavpack.sym")
     endif()

--- a/src/open_filename.c
+++ b/src/open_filename.c
@@ -73,6 +73,8 @@ static FILE *fopen_utf8 (const char *filename_utf8, const char *mode_utf8);
 #define _fseeki64 fseeko64
 #endif
 
+#if !defined(DISABLE_WavpackOpenFileInput)
+
 static int32_t read_bytes (void *id, void *data, int32_t bcount)
 {
     return (int32_t) fread (data, 1, bcount, (FILE*) id);
@@ -299,6 +301,8 @@ WavpackContext *WavpackOpenFileInput (const char *infilename, char *error, int f
 
     return WavpackOpenFileInputEx64 (&freader, wv_id, wvc_id, error, flags, norm_offset);
 }
+
+#endif
 
 #ifdef _WIN32
 


### PR DESCRIPTION
`ftruncate` is used through `WavpackOpenFileInput`.
This patch "mutilates" wavpack to disable this wavpack api function (only for ps2 and psp).

SDL_mixer needs https://github.com/libsdl-org/SDL_mixer/pull/586.
