### PR TITLE
Compile SDL_mixer with SDLMIXER_VENDORED ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,9 @@ target_compile_definitions(wavpack
         $<$<AND:$<BOOL:${WAVPACK_ENABLE_ASM}>,$<BOOL:${WavPack_CPU_X64}>>:OPT_ASM_X64>
         $<$<AND:$<BOOL:${WAVPACK_ENABLE_ASM}>,$<BOOL:${WavPack_CPU_ARM32}>>:OPT_ASM_ARM32>
 )
+target_compile_definitions(wavpack PRIVATE
+    _POSIX_C_SOURCE=200809L
+)
 
 if(WAVPACK_ENABLE_ASM AND HAVE_MASM AND WavPack_CPU_X86)
 	set_source_files_properties(src/pack_x86.asm src/unpack_x86.asm PROPERTIES COMPILE_FLAGS "/safeseh")

--- a/src/tag_utils.c
+++ b/src/tag_utils.c
@@ -21,6 +21,7 @@
 #ifdef _WIN32
 #define stricmp(x,y) _stricmp(x,y)
 #else
+#include <strings.h>
 #define stricmp strcasecmp
 #endif
 #endif


### PR DESCRIPTION
`_POSIX_C_SOURCE=200809L` fixes
```
[2/296] Building C object SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/open_filename.c.o
FAILED: [code=1] SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/open_filename.c.o
/usr/bin/gcc-14 -DENABLE_DSD -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X64 -Dwavpack_EXPORTS -I/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/include -O3 -DNDEBUG -std=c99 -Wall -Wdisabled-optimization -Wextra -Wfloat-conversion -Wformat=2 -Wimplicit-function-declaration -Wlogical-op -Wpointer-arith -Wsign-compare -Wtype-limits -Wuninitialized -Wunused -Wvla -Wstack-usage=100000 -Wshadow -Wundef -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -fdiagnostics-color=always -Wall -MD -MT SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/open_filename.c.o -MF SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/open_filename.c.o.d -o SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/open_filename.c.o -c /mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/open_filename.c
/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/open_filename.c: In function ‘can_seek’:
/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/open_filename.c:139:28: error: implicit declaration of function ‘fileno’ [-Wimplicit-function-declaration]
  139 |     return file && !fstat (fileno (file), &statbuf) && S_ISREG(statbuf.st_mode);
      |                            ^~~~~~
/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/open_filename.c: In function ‘truncate_here’:
/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/open_filename.c:208:12: error: implicit declaration of function ‘ftruncate’; did you mean ‘strncat’? [-Wimplicit-function-declaration]
  208 |     return ftruncate (fileno (file), curr_pos);
      |            ^~~~~~~~~
      |            strncat
```

`#include <strings.h>` fixes
```
[262/296] Building C object SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/tag_utils.c.o
FAILED: [code=1] SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/tag_utils.c.o
/usr/bin/gcc-14 -DENABLE_DSD -DHAVE_FSEEKO -DHAVE___BUILTIN_CLZ -DOPT_ASM_X64 -D_POSIX_C_SOURCE=200809L -Dwavpack_EXPORTS -I/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/include -O3 -DNDEBUG -std=c99 -Wall -Wdisabled-optimization -Wextra -Wfloat-conversion -Wformat=2 -Wimplicit-function-declaration -Wlogical-op -Wpointer-arith -Wsign-compare -Wtype-limits -Wuninitialized -Wunused -Wvla -Wstack-usage=100000 -Wshadow -Wundef -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC -fdiagnostics-color=always -Wall -MD -MT SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/tag_utils.c.o -MF SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/tag_utils.c.o.d -o SDL_mixer/external/wavpack-build/CMakeFiles/wavpack.dir/src/tag_utils.c.o -c /mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/tag_utils.c
/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/tag_utils.c: In function ‘WavpackDeleteTagItem’:
/mnt/HDExtra/GithubProjects/SDL3/SDL_mixer/external/wavpack/src/tag_utils.c:24:17: error: implicit declaration of function ‘strcasecmp’; did you mean ‘strncmp’? [-Wimplicit-function-declaration]
   24 | #define stricmp strcasecmp
      |                 ^~~~~~~~~~
```